### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/cosminnicula/b5b92e5f-ae3b-49e9-b3e3-46443a0eeb2e/089d74ec-411c-4d06-a5af-083b0346a88c/_apis/work/boardbadge/2e39d243-7c23-4f27-9039-1567c3be9c9b)](https://dev.azure.com/cosminnicula/b5b92e5f-ae3b-49e9-b3e3-46443a0eeb2e/_boards/board/t/089d74ec-411c-4d06-a5af-083b0346a88c/Microsoft.RequirementCategory)
 # starlight
 starlight


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#7](https://dev.azure.com/cosminnicula/b5b92e5f-ae3b-49e9-b3e3-46443a0eeb2e/_workitems/edit/7). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.